### PR TITLE
Avoid detecting self, and track a set of peers

### DIFF
--- a/examples/local.rs
+++ b/examples/local.rs
@@ -9,6 +9,9 @@ use swarm_discovery::Discoverer;
 use tokio::runtime::Builder;
 use tracing_subscriber::{fmt, EnvFilter};
 
+/// To run this example:
+/// In two (or more) different terminals run: `cargo run --example local`
+/// and each one will discover the other peer and track a peer set containing them all
 fn main() {
     // enable logging: use `RUST_LOG=debug` or similar to see logs on STDERR
     fmt()
@@ -48,9 +51,15 @@ fn main() {
     let _guard = Discoverer::new_interactive("swarm".to_owned(), my_peer_id.clone())
         .with_addrs(port, addrs.iter().take(1).copied())
         .with_addrs(port + 1, addrs)
-        .with_callback(move |peer_id, addrs| {
+        .with_callback(move |peer_id, peer| {
             if peer_set.insert(peer_id.to_string()) {
-                println!("new peer discovered {}: {:?}", peer_id, addrs);
+                println!("new peer discovered {peer_id}: {:?}", peer);
+                println!("peer set: {:?}", peer_set);
+            }
+
+            if peer.addrs().is_empty() {
+                println!("peer removed: {peer_id}");
+                peer_set.remove(peer_id);
                 println!("peer set: {:?}", peer_set);
             }
         })

--- a/examples/local.rs
+++ b/examples/local.rs
@@ -4,6 +4,7 @@ use std::{
     io::{stderr, stdin},
     net::UdpSocket,
 };
+use std::collections::HashSet;
 use swarm_discovery::Discoverer;
 use tokio::runtime::Builder;
 use tracing_subscriber::{fmt, EnvFilter};
@@ -22,7 +23,7 @@ fn main() {
         .expect("build runtime");
 
     // make up some peer ID
-    let peer_id = format!("peer_id{}", thread_rng().gen_range(0..100));
+    let my_peer_id = format!("peer_id{}", thread_rng().gen_range(0..100));
 
     // get local addresses and make up some port
     let addrs = get_if_addrs()
@@ -36,15 +37,22 @@ fn main() {
         .expect("local_addr")
         .port();
 
-    println!("peer_id: {}", peer_id);
+    println!("my_peer_id: {}", my_peer_id);
     println!("addrs: {:?}", addrs);
 
+    let mut peer_set : HashSet<String> = HashSet::new();
+    peer_set.insert(my_peer_id.clone());
+    println!("peer set: {:?}", peer_set);
+
     // start announcing and discovering
-    let _guard = Discoverer::new_interactive("swarm".to_owned(), peer_id)
+    let _guard = Discoverer::new_interactive("swarm".to_owned(), my_peer_id.clone())
         .with_addrs(port, addrs.iter().take(1).copied())
         .with_addrs(port + 1, addrs)
-        .with_callback(|peer_id, addrs| {
-            println!("discovered {}: {:?}", peer_id, addrs);
+        .with_callback(move |peer_id, addrs| {
+            if peer_set.insert(peer_id.to_string()) {
+                println!("new peer discovered {}: {:?}", peer_id, addrs);
+                println!("peer set: {:?}", peer_set);
+            }
         })
         .spawn(rt.handle())
         .expect("discoverer spawn");


### PR DESCRIPTION
Make the example a little more readable while running by:
- not constantly printing our peer detection of self
- just detect peer addition or removal/loss
- track a set of peers known about and print it out when peer joins/leaves the set