### PR TITLE
feat: Update `hickory-proto` dependency to v0.25.0-alpha.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde = ["dep:serde"]
 [dependencies]
 acto = { version = "0.7.0", features = ["tokio"] }
 anyhow = "1.0.79"
-hickory-proto = "0.24.0"
+hickory-proto = "=0.25.0-alpha.4"
 rand = "0.8.5"
 serde = { version = "1.0.195", features = ["derive"], optional = true }
 socket2 = { version = "0.5.5", features = ["all"] }

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -88,7 +88,7 @@ fn handle_msg(buf: &[u8], service_name: &Name, addr: IpAddr) -> Option<MdnsMsg> 
             );
             continue;
         };
-        let Some(RData::SRV(srv)) = response.data() else {
+        let RData::SRV(srv) = response.data() else {
             tracing::trace!(
                 "received mDNS response with wrong data {:?}",
                 response.data()
@@ -117,8 +117,8 @@ fn handle_msg(buf: &[u8], service_name: &Name, addr: IpAddr) -> Option<MdnsMsg> 
         }
         tracing::trace!("received mDNS additional for {}", name);
         let ip: IpAddr = match additional.data() {
-            Some(RData::A(a)) => a.0.into(),
-            Some(RData::AAAA(a)) => a.0.into(),
+            RData::A(a) => a.0.into(),
+            RData::AAAA(a) => a.0.into(),
             _ => {
                 tracing::debug!(
                     "received mDNS additional with wrong data {:?}",


### PR DESCRIPTION
This updates `swarm-discovery` to use the new hickory-proto version.

Ideally, this gets released *soon*. Until then, either this branch can live on, or a swarm-discovery alpha is published. Not sure what the right cause of action is right now.

This should be somewhat useful nonetheless.