### PR TITLE
Add support for TXT records with key-value attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,5 +62,6 @@ The facilities described in [RFC6762](https://datatracker.ietf.org/doc/html/rfc6
 - configurable service name NAME
 - queries sent for PTR records of the form `_NAME._udp.local.` (TCP analog)
 - responses give SRV records of the form `PEER_ID._NAME._udp.local.` -> `PEER_ID.local.` (and associated A/AAAA records)
+- responses may include a TXT record with the same name as the SRV record, containing a list of key-value attribute pairs as described in [RFC 6763](https://datatracker.ietf.org/doc/html/rfc6763#section-6)
 
 If multiple ports are associated to their respective IP addresses, there will be one SRV record per port pointing to a resource name of the form `PEER_ID-PORT._NAME._udp.local`.

--- a/src/guardian.rs
+++ b/src/guardian.rs
@@ -13,7 +13,9 @@ pub enum Input {
     RemoveAll,
     RemovePort(u16),
     RemoveAddr(IpAddr),
-    Add(u16, Vec<IpAddr>),
+    AddAddr(u16, Vec<IpAddr>),
+    AddTxt(String, String),
+    RemoveTxt(String),
 }
 
 pub async fn guardian(

--- a/src/guardian.rs
+++ b/src/guardian.rs
@@ -14,7 +14,7 @@ pub enum Input {
     RemovePort(u16),
     RemoveAddr(IpAddr),
     AddAddr(u16, Vec<IpAddr>),
-    AddTxt(String, String),
+    SetTxt(String, Option<String>),
     RemoveTxt(String),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,9 +214,10 @@ impl Discoverer {
     }
 
     /// Sets TXT records for this peer.
-    pub fn with_txt(mut self, txt: TxtData) {
+    pub fn with_txt(mut self, txt: TxtData) -> Self {
         let me = self.peers.entry(self.peer_id.clone()).or_default();
         me.txt.extend(txt.into_iter());
+        self
     }
 
     /// Register a callback to be called when a peer is discovered or its addresses change.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,10 +108,21 @@ impl Peer {
     /// Returns an iterator of the key-value pairs set by this peer.
     ///
     /// [RFC 6763]: https://datatracker.ietf.org/doc/html/rfc6763#section-6
-    pub fn txt(&self) -> impl Iterator<Item = (&str, Option<&str>)> + '_ {
+    pub fn txt_attributes(&self) -> impl Iterator<Item = (&str, Option<&str>)> + '_ {
         self.txt
             .iter()
             .map(|(k, v)| (k.as_str(), v.as_ref().map(|v| v.as_str())))
+    }
+
+    /// Returns the value for a TXT attribute for this peer.
+    ///
+    /// See [`Self::txt_attributes`] for details.
+    ///
+    /// Returns `None` if the attribute is missing.
+    /// Returns `Some(None)` if the attribute is a boolean, i.e. has no value.
+    /// Returns `Some(Some(value))` if the attribute has a value.
+    pub fn txt_attribute(&self, name: &str) -> Option<Option<&str>> {
+        self.txt.get(name).map(|x| x.as_deref())
     }
 }
 

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -99,14 +99,19 @@ fn handle_msg(buf: &[u8], service_name: &Name, addr: IpAddr) -> Option<MdnsMsg> 
                     let Ok(s) = std::str::from_utf8(&s) else {
                         continue;
                     };
-                    let mut parts = s.split('=');
-                    let (Some(key), Some(value)) = (parts.next(), parts.next()) else {
+                    if s.is_empty() {
                         continue;
+                    }
+                    let (key, value) = match s.split_once('=') {
+                        Some((key, value)) => (key, Some(value)),
+                        None => (s, None),
                     };
+                    let key = key.to_string();
+                    let value = value.map(ToString::to_string);
                     peer_txt
                         .entry(peer_id.to_string())
                         .or_default()
-                        .insert(key.to_string(), value.to_string());
+                        .insert(key, value);
                 }
             }
             _ => {

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -62,7 +62,7 @@ fn handle_msg(buf: &[u8], service_name: &Name, addr: IpAddr) -> Option<MdnsMsg> 
     let local = Name::from_str("local.").unwrap();
 
     let mut peer_ports: BTreeMap<Name, Vec<(u16, String)>> = BTreeMap::new();
-    let mut peer_id = None;
+    let mut peer_txt: BTreeMap<String, TxtData> = BTreeMap::new();
     for response in packet.answers() {
         if response.dns_class() != DNSClass::IN {
             tracing::trace!(
@@ -80,40 +80,45 @@ fn handle_msg(buf: &[u8], service_name: &Name, addr: IpAddr) -> Option<MdnsMsg> 
         let Some(peer_id_bytes) = name.iter().next() else {
             continue;
         };
-        let Ok(response_peer_id) = std::str::from_utf8(peer_id_bytes) else {
+        let Ok(peer_id) = std::str::from_utf8(peer_id_bytes) else {
             tracing::debug!(
                 "received mDNS response with invalid peer ID {:?}",
                 peer_id_bytes
             );
             continue;
         };
-        match &peer_id {
-            None => {
-                peer_id = Some(response_peer_id);
+        match response.data() {
+            RData::SRV(srv) => {
+                peer_ports
+                    .entry(srv.target().clone())
+                    .or_default()
+                    .push((srv.port(), peer_id.to_string()));
             }
-            Some(peer_id) if *peer_id == response_peer_id => {}
+            RData::TXT(txt) => {
+                for s in txt.iter() {
+                    let Ok(s) = std::str::from_utf8(&s) else {
+                        continue;
+                    };
+                    let mut parts = s.split('=');
+                    let (Some(key), Some(value)) = (parts.next(), parts.next()) else {
+                        continue;
+                    };
+                    peer_txt
+                        .entry(peer_id.to_string())
+                        .or_default()
+                        .insert(key.to_string(), value.to_string());
+                }
+            }
             _ => {
-                tracing::debug!(
-                    "received mDNS response with peer id different from first peer id, skip"
+                tracing::trace!(
+                    "received mDNS response with wrong data {:?}",
+                    response.data()
                 );
-                continue;
             }
         }
-        let RData::SRV(srv) = response.data() else {
-            tracing::trace!(
-                "received mDNS response with wrong data {:?}",
-                response.data()
-            );
-            continue;
-        };
-        peer_ports
-            .entry(srv.target().clone())
-            .or_default()
-            .push((srv.port(), response_peer_id.to_string()));
     }
 
     let mut peer_addrs: BTreeMap<String, Vec<(IpAddr, u16)>> = BTreeMap::new();
-    let mut peer_txt: BTreeMap<String, TxtData> = BTreeMap::new();
     for additional in packet.additionals() {
         if additional.dns_class() != DNSClass::IN {
             tracing::trace!(
@@ -123,20 +128,14 @@ fn handle_msg(buf: &[u8], service_name: &Name, addr: IpAddr) -> Option<MdnsMsg> 
             continue;
         }
         let name = additional.name();
-        if !local.zone_of(&name) {
+        if name.base_name() != local {
             tracing::trace!("received mDNS additional for wrong service {}", name);
             continue;
         }
         tracing::trace!("received mDNS additional for {}", name);
-        #[derive(Debug)]
-        enum Kind {
-            Ip(IpAddr),
-            Txt(String),
-        }
-        let kind = match additional.data() {
-            RData::A(a) => Kind::Ip(a.0.into()),
-            RData::AAAA(a) => Kind::Ip(a.0.into()),
-            RData::TXT(txt) => Kind::Txt(txt.to_string()),
+        let ip: IpAddr = match additional.data() {
+            RData::A(a) => a.0.into(),
+            RData::AAAA(a) => a.0.into(),
             _ => {
                 tracing::debug!(
                     "received mDNS additional with wrong data {:?}",
@@ -145,35 +144,11 @@ fn handle_msg(buf: &[u8], service_name: &Name, addr: IpAddr) -> Option<MdnsMsg> 
                 continue;
             }
         };
-        match kind {
-            Kind::Ip(ip) => {
-                for (port, peer_id) in peer_ports.get(name).map(|x| &**x).unwrap_or(&[]) {
-                    peer_addrs
-                        .entry(peer_id.clone())
-                        .or_default()
-                        .push((ip, *port));
-                }
-            }
-            Kind::Txt(txt) => {
-                if name.num_labels() != 3 {
-                    tracing::debug!("received mDNS additional TXT with wrong label count, skip");
-                    continue;
-                }
-                let Some(peer_id) = &peer_id else {
-                    tracing::debug!("received mDNS additional TXT with wrong peer id, skip");
-                    continue;
-                };
-                let Ok(txt_name) =
-                    String::from_utf8(name.iter().next().expect("just checked").to_vec())
-                else {
-                    tracing::debug!("received mDNS additional TXT with non-utf8 label, skip");
-                    continue;
-                };
-                peer_txt
-                    .entry(peer_id.to_string())
-                    .or_default()
-                    .insert(txt_name, txt);
-            }
+        for (port, peer_id) in peer_ports.get(name).map(|x| &**x).unwrap_or(&[]) {
+            peer_addrs
+                .entry(peer_id.clone())
+                .or_default()
+                .push((ip, *port));
         }
     }
     let mut ret = BTreeMap::new();

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -106,12 +106,10 @@ fn handle_msg(buf: &[u8], service_name: &Name, addr: IpAddr) -> Option<MdnsMsg> 
                         Some((key, value)) => (key, Some(value)),
                         None => (s, None),
                     };
-                    let key = key.to_string();
-                    let value = value.map(ToString::to_string);
-                    peer_txt
-                        .entry(peer_id.to_string())
-                        .or_default()
-                        .insert(key, value);
+                    let map = peer_txt.entry(peer_id.to_string()).or_default();
+                    if !map.contains_key(key) {
+                        map.insert(key.to_string(), value.map(ToString::to_string));
+                    }
                 }
             }
             _ => {

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -1,13 +1,11 @@
-use crate::{sender::MdnsMsg, Peer};
+use crate::{sender::MdnsMsg, Peer, TxtData};
 use acto::{ActoCell, ActoRef, ActoRuntime};
 use anyhow::Context;
 use hickory_proto::{
     op::Message,
     rr::{DNSClass, Name, RData, RecordType},
 };
-use std::{
-    borrow::Cow, collections::BTreeMap, net::IpAddr, str::FromStr, sync::Arc, time::Instant,
-};
+use std::{collections::BTreeMap, net::IpAddr, str::FromStr, sync::Arc, time::Instant};
 use tokio::net::UdpSocket;
 
 pub async fn receiver(
@@ -64,6 +62,7 @@ fn handle_msg(buf: &[u8], service_name: &Name, addr: IpAddr) -> Option<MdnsMsg> 
     let local = Name::from_str("local.").unwrap();
 
     let mut peer_ports: BTreeMap<Name, Vec<(u16, String)>> = BTreeMap::new();
+    let mut peer_id = None;
     for response in packet.answers() {
         if response.dns_class() != DNSClass::IN {
             tracing::trace!(
@@ -81,13 +80,25 @@ fn handle_msg(buf: &[u8], service_name: &Name, addr: IpAddr) -> Option<MdnsMsg> 
         let Some(peer_id_bytes) = name.iter().next() else {
             continue;
         };
-        let Cow::Borrowed(peer_id) = String::from_utf8_lossy(peer_id_bytes) else {
+        let Ok(response_peer_id) = std::str::from_utf8(peer_id_bytes) else {
             tracing::debug!(
                 "received mDNS response with invalid peer ID {:?}",
                 peer_id_bytes
             );
             continue;
         };
+        match &peer_id {
+            None => {
+                peer_id = Some(response_peer_id);
+            }
+            Some(peer_id) if *peer_id == response_peer_id => {}
+            _ => {
+                tracing::debug!(
+                    "received mDNS response with peer id different from first peer id, skip"
+                );
+                continue;
+            }
+        }
         let RData::SRV(srv) = response.data() else {
             tracing::trace!(
                 "received mDNS response with wrong data {:?}",
@@ -98,10 +109,11 @@ fn handle_msg(buf: &[u8], service_name: &Name, addr: IpAddr) -> Option<MdnsMsg> 
         peer_ports
             .entry(srv.target().clone())
             .or_default()
-            .push((srv.port(), peer_id.to_owned()));
+            .push((srv.port(), response_peer_id.to_string()));
     }
 
     let mut peer_addrs: BTreeMap<String, Vec<(IpAddr, u16)>> = BTreeMap::new();
+    let mut peer_txt: BTreeMap<String, TxtData> = BTreeMap::new();
     for additional in packet.additionals() {
         if additional.dns_class() != DNSClass::IN {
             tracing::trace!(
@@ -111,14 +123,20 @@ fn handle_msg(buf: &[u8], service_name: &Name, addr: IpAddr) -> Option<MdnsMsg> 
             continue;
         }
         let name = additional.name();
-        if name.base_name() != local {
+        if !local.zone_of(&name) {
             tracing::trace!("received mDNS additional for wrong service {}", name);
             continue;
         }
         tracing::trace!("received mDNS additional for {}", name);
-        let ip: IpAddr = match additional.data() {
-            RData::A(a) => a.0.into(),
-            RData::AAAA(a) => a.0.into(),
+        #[derive(Debug)]
+        enum Kind {
+            Ip(IpAddr),
+            Txt(String),
+        }
+        let kind = match additional.data() {
+            RData::A(a) => Kind::Ip(a.0.into()),
+            RData::AAAA(a) => Kind::Ip(a.0.into()),
+            RData::TXT(txt) => Kind::Txt(txt.to_string()),
             _ => {
                 tracing::debug!(
                     "received mDNS additional with wrong data {:?}",
@@ -127,19 +145,48 @@ fn handle_msg(buf: &[u8], service_name: &Name, addr: IpAddr) -> Option<MdnsMsg> 
                 continue;
             }
         };
-        for (port, peer_id) in peer_ports.get(name).map(|x| &**x).unwrap_or(&[]) {
-            peer_addrs
-                .entry(peer_id.clone())
-                .or_default()
-                .push((ip, *port));
+        match kind {
+            Kind::Ip(ip) => {
+                for (port, peer_id) in peer_ports.get(name).map(|x| &**x).unwrap_or(&[]) {
+                    peer_addrs
+                        .entry(peer_id.clone())
+                        .or_default()
+                        .push((ip, *port));
+                }
+            }
+            Kind::Txt(txt) => {
+                if name.num_labels() != 3 {
+                    tracing::debug!("received mDNS additional TXT with wrong label count, skip");
+                    continue;
+                }
+                let Some(peer_id) = &peer_id else {
+                    tracing::debug!("received mDNS additional TXT with wrong peer id, skip");
+                    continue;
+                };
+                let Ok(txt_name) =
+                    String::from_utf8(name.iter().next().expect("just checked").to_vec())
+                else {
+                    tracing::debug!("received mDNS additional TXT with non-utf8 label, skip");
+                    continue;
+                };
+                peer_txt
+                    .entry(peer_id.to_string())
+                    .or_default()
+                    .insert(txt_name, txt);
+            }
         }
     }
     let mut ret = BTreeMap::new();
     for (peer_id, mut addrs) in peer_addrs {
         addrs.sort_unstable();
         addrs.dedup();
+        let txt = peer_txt.remove(&peer_id).unwrap_or_default();
         let last_seen = Instant::now();
-        let peer = Peer { addrs, last_seen };
+        let peer = Peer {
+            addrs,
+            last_seen,
+            txt,
+        };
         ret.insert(peer_id, peer);
     }
     Some(MdnsMsg::Response(ret))

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -206,14 +206,11 @@ fn make_response(discoverer: &Discoverer, service_name: &Name) -> Option<Message
                 }
             }
         }
-        for (txt_name, txt_value) in &peer.txt {
-            let Ok(name) = Name::from_str(&format!("{}.{}.local", txt_name, discoverer.peer_id))
-            else {
-                tracing::warn!("invalid txt_name: {txt_name}");
-                continue;
-            };
-            let rdata = TXT::new(vec![txt_value.clone()]);
-            msg.add_additional(Record::from_rdata(name, 0, RData::TXT(rdata)));
+        if !peer.txt.is_empty() {
+            let parts = peer.txt.iter().map(|(k, v)| format!("{k}={v}")).collect();
+            let rdata = TXT::new(parts);
+            let record = Record::from_rdata(my_srv_name, 0, RData::TXT(rdata));
+            msg.add_answer(record);
         }
         Some(msg)
     } else {

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -207,7 +207,20 @@ fn make_response(discoverer: &Discoverer, service_name: &Name) -> Option<Message
             }
         }
         if !peer.txt.is_empty() {
-            let parts = peer.txt.iter().map(|(k, v)| format!("{k}={v}")).collect();
+            let parts = peer
+                .txt
+                .iter()
+                .filter_map(|(k, v)| {
+                    if k.is_empty() {
+                        None
+                    } else {
+                        Some(match v {
+                            None => k.to_string(),
+                            Some(v) => format!("{k}={v}"),
+                        })
+                    }
+                })
+                .collect();
             let rdata = TXT::new(parts);
             let record = Record::from_rdata(my_srv_name, 0, RData::TXT(rdata));
             msg.add_answer(record);
@@ -253,7 +266,7 @@ fn update_response(
             }
             make_response(discoverer, service_name)
         }
-        guardian::Input::AddTxt(key, value) => {
+        guardian::Input::SetTxt(key, value) => {
             let peer = discoverer
                 .peers
                 .entry(discoverer.peer_id.clone())

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -258,7 +258,7 @@ fn update_response(
             let peer = discoverer
                 .peers
                 .entry(discoverer.peer_id.clone())
-                .or_default();
+                .or_insert_with(Peer::new);
             for addr in addrs {
                 peer.addrs.push((addr, port));
                 peer.addrs.sort_unstable();
@@ -270,7 +270,7 @@ fn update_response(
             let peer = discoverer
                 .peers
                 .entry(discoverer.peer_id.clone())
-                .or_default();
+                .or_insert_with(Peer::new);
             peer.txt.insert(key, value);
             make_response(discoverer, service_name)
         }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -67,6 +67,7 @@ pub async fn updater(
                             &Peer {
                                 last_seen: peer.last_seen,
                                 addrs: vec![],
+                                txt: Default::default(),
                             },
                         );
                     }

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -27,6 +27,7 @@ fn test() {
             host: String,
             peer: String,
             addrs: Vec<(IpAddr, u16)>,
+            txt: BTreeMap<String, String>,
         },
         Forget {
             host: String,
@@ -57,6 +58,10 @@ fn test() {
             .map(|iface| iface.addr.ip())
             .collect::<Vec<_>>();
 
+        let mut txt = BTreeMap::new();
+        txt.insert("name".to_string(), format!("peer={peer_id}"));
+        txt.insert("foo".to_string(), "bar".to_string());
+
         let _guard = Discoverer::new("swarm".to_owned(), peer_id.clone())
             .with_protocol(protocol)
             .with_addrs(port + 10, addrs.iter().take(1).copied())
@@ -72,12 +77,17 @@ fn test() {
                         host: peer_id.clone(),
                         peer: pid.to_owned(),
                         addrs: peer.addrs().to_owned(),
+                        txt: peer
+                            .txt()
+                            .map(|(k, v)| (k.to_string(), v.to_string()))
+                            .collect(),
                     }
                 };
                 snd.send(msg).expect("send");
             })
             .with_cadence(tau)
             .with_response_rate(phi)
+            .with_txt(txt)
             .spawn(rt.handle())
             .expect("discoverer spawn");
 
@@ -337,8 +347,12 @@ fn test() {
             tx_f.clone(),
         ));
 
-        let Disco::Discover { host, peer, addrs } =
-            rx_f.try_recv_timeout(Duration::from_secs(5)).expect("recv")
+        let Disco::Discover {
+            host,
+            peer,
+            addrs,
+            txt,
+        } = rx_f.try_recv_timeout(Duration::from_secs(5)).expect("recv")
         else {
             panic!("no discovery");
         };
@@ -358,6 +372,11 @@ fn test() {
         let addrs = addr_map.get(port1).expect("port1");
         assert!(addrs.len() > 1);
         assert!(addrs.iter().any(|a| *a == addr));
+
+        let mut expected_txt = BTreeMap::new();
+        expected_txt.insert("foo".to_string(), "bar".to_string());
+        expected_txt.insert("name".to_string(), format!("peer={peer}"));
+        assert_eq!(txt, expected_txt, "txt mismatch");
 
         tx1.send(()).expect("send");
         tx2.send(()).expect("send");

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -79,7 +79,7 @@ fn test() {
                         peer: pid.to_owned(),
                         addrs: peer.addrs().to_owned(),
                         txt: peer
-                            .txt()
+                            .txt_attributes()
                             .map(|(k, v)| (k.to_string(), v.map(ToString::to_string)))
                             .collect(),
                     }

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -60,7 +60,7 @@ fn test() {
 
         let mut attributes = BTreeMap::new();
         attributes.insert("name".to_string(), Some(format!("peer={peer_id}")));
-        attributes.insert("foo".to_string(), Some("bar".to_string()));
+        attributes.insert("føø".to_string(), Some("bär".to_string()));
         attributes.insert("bool".to_string(), None);
 
         let _guard = Discoverer::new("swarm".to_owned(), peer_id.clone())
@@ -376,7 +376,7 @@ fn test() {
         assert!(addrs.iter().any(|a| *a == addr));
 
         let mut expected_txt = BTreeMap::new();
-        expected_txt.insert("foo".to_string(), Some("bar".to_string()));
+        expected_txt.insert("føø".to_string(), Some("bär".to_string()));
         expected_txt.insert("name".to_string(), Some(format!("peer={peer}")));
         expected_txt.insert("bool".to_string(), None);
         assert_eq!(txt, expected_txt, "txt mismatch");


### PR DESCRIPTION
This PR adds support for an optional TXT record that is sent in responses. The TXT record contains a list of key-value attribute pairs, as described in [RFC 6763](https://datatracker.ietf.org/doc/html/rfc6763#section-6).

This allows for peers to attach arbitrary key-value strings to describe themselves.

Each key-value pair may be at most 255 bytes long (254 excluding the `=` to separate key and value). This is checked. It is currently not checked that the total size of all key-value pairs is low enough, so that the DNS message still fits into a single UDP packet. The current API does not really allow for this check I think. Instead, I added a note to the docs that it is up to the caller to keep the amount of key-value pairs low enough. It is difficult to enforce a global limit here, because a) it depends on the UDP MTU, and b) we only really know at the time of creating the DNS message, because it depends, of course, on the size of service name, peer id and the amount of addresses as well.