### PR TITLE
fix: update hickory-proto to alpha.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde = ["dep:serde"]
 [dependencies]
 acto = { version = "0.7.0", features = ["tokio"] }
 anyhow = "1.0.79"
-hickory-proto = "=0.25.0-alpha.4"
+hickory-proto = "=0.25.0-alpha.5"
 rand = "0.8.5"
 serde = { version = "1.0.195", features = ["derive"], optional = true }
 socket2 = { version = "0.5.5", features = ["all"] }


### PR DESCRIPTION
Needed to resolve https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-37wc-h8xc-5hc4