### PR TITLE
chore: Update hickory-proto to version 0.25.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde = ["dep:serde"]
 [dependencies]
 acto = { version = "0.7.0", features = ["tokio"] }
 anyhow = "1.0.79"
-hickory-proto = "=0.25.0-alpha.5"
+hickory-proto = "0.25.1"
 rand = "0.8.5"
 serde = { version = "1.0.195", features = ["derive"], optional = true }
 socket2 = { version = "0.5.5", features = ["all"] }


### PR DESCRIPTION
Updates due to the version might possibly cool down finally, now that 0.25 is released and we're out of alpha.

I ran `cargo test --all-features` locally, and it seems to be fine.