### PR TITLE
refactor: replace `anyhow` errors with concrete error types, using `snafu`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,16 @@ serde = ["dep:serde"]
 
 [dependencies]
 acto = { version = "0.7.0", features = ["tokio"] }
-snafu = "0.8.5"
 hickory-proto = "0.25.1"
 rand = "0.8.5"
 serde = { version = "1.0.195", features = ["derive"], optional = true }
 socket2 = { version = "0.5.5", features = ["all"] }
 tokio = { version = "1.35.1", features = ["macros", "net", "rt", "time"] }
+thiserror = "2"
 tracing = "0.1.40"
 
 [dev-dependencies]
+anyhow = "1"
 if-addrs = "0.11.0"
 ipc-channel = "0.18.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = ["dep:serde"]
 
 [dependencies]
 acto = { version = "0.7.0", features = ["tokio"] }
-anyhow = "1.0.79"
+snafu = "0.8.5"
 hickory-proto = "0.25.1"
 rand = "0.8.5"
 serde = { version = "1.0.195", features = ["derive"], optional = true }

--- a/src/guardian.rs
+++ b/src/guardian.rs
@@ -1,5 +1,5 @@
 use crate::{
-    receiver::receiver,
+    receiver::{receiver, ReceiverError},
     sender::{self, sender},
     socket::Sockets,
     updater::updater,
@@ -19,7 +19,7 @@ pub enum Input {
 }
 
 pub async fn guardian(
-    mut ctx: ActoCell<Input, AcTokioRuntime, anyhow::Result<()>>,
+    mut ctx: ActoCell<Input, AcTokioRuntime, Result<(), ReceiverError>>,
     mut discoverer: Discoverer,
     sockets: Sockets,
     service_name: Name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@ mod socket;
 mod updater;
 
 use acto::{AcTokio, ActoHandle, ActoRef, ActoRuntime, SupervisionRef, TokioJoinHandle};
-use anyhow::{anyhow, Context};
 use hickory_proto::rr::Name;
-use socket::Sockets;
+use snafu::prelude::*;
+use socket::{SocketError, Sockets};
 use std::{
     collections::BTreeMap,
     fmt::Display,
@@ -22,6 +22,40 @@ use tokio::runtime::Handle;
 type Callback = Box<dyn FnMut(&str, &Peer) + Send + 'static>;
 
 pub(crate) type TxtData = BTreeMap<String, Option<String>>;
+
+/// Errors that can occur when spawning a swarm discovery service.
+#[derive(Debug, Snafu)]
+pub enum SpawnError {
+    #[snafu(transparent)]
+    Sockets { source: SocketError },
+    #[snafu(display(
+        "Cannot construct service name from name '{name}' and protocol '{protocol}'"
+    ))]
+    ServiceName {
+        source: hickory_proto::ProtoError,
+        name: String,
+        protocol: Protocol,
+    },
+    #[snafu(display("Cannot construct name from peer ID {peer_id}"))]
+    NameFromPeerId {
+        source: hickory_proto::ProtoError,
+        peer_id: String,
+    },
+    #[snafu(display("Cannot append service name '{service_name}' to peer ID"))]
+    AppendServiceName {
+        source: hickory_proto::ProtoError,
+        service_name: Name,
+    },
+}
+
+/// Errors that can occur when validating a txt attribute.
+#[derive(Debug, Snafu)]
+pub enum TxtAttributeError {
+    #[snafu(display("Key may not be empty"))]
+    EmptyKey,
+    #[snafu(display("Key-value pair is too long, must be shorter than 254 bytes"))]
+    TooLong,
+}
 
 /// Builder for a swarm discovery service.
 ///
@@ -256,7 +290,7 @@ impl Discoverer {
     pub fn with_txt_attributes(
         mut self,
         attributes: impl IntoIterator<Item = (String, Option<String>)>,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self, TxtAttributeError> {
         let me = self
             .peers
             .entry(self.peer_id.clone())
@@ -322,18 +356,25 @@ impl Discoverer {
     ///
     /// This will spawn asynchronous tasks and return a guard which will stop the discovery when dropped.
     /// Changing the configuration is done by stopping the discovery and starting a new one.
-    pub fn spawn(self, handle: &Handle) -> anyhow::Result<DropGuard> {
+    pub fn spawn(self, handle: &Handle) -> Result<DropGuard, SpawnError> {
         let _entered = handle.enter();
         let sockets = Sockets::new(self.class)?;
         tracing::trace!(?sockets, "created new sockets");
 
         let service_name = Name::from_str(&format!("_{}.{}.local.", self.name, self.protocol))
-            .context("constructing service name")?;
+            .context(ServiceNameSnafu {
+                name: self.name.clone(),
+                protocol: self.protocol,
+            })?;
         // need to test this here so it won't fail in the actor
         Name::from_str(&self.peer_id)
-            .context("constructing name from peer ID")?
+            .context(NameFromPeerIdSnafu {
+                peer_id: self.peer_id.clone(),
+            })?
             .append_domain(&service_name)
-            .context("appending service name to peer ID")?;
+            .context(AppendServiceNameSnafu {
+                service_name: service_name.clone(),
+            })?;
 
         let rt = AcTokio::from_handle("swarm-discovery", handle.clone());
         let SupervisionRef { me, handle } = rt.spawn_actor("guardian", move |ctx| {
@@ -390,7 +431,11 @@ impl DropGuard {
     /// The total length of all attributes is not checked here. You should make sure
     /// to keep the total length of all attributes at a few hundred bytes so that
     /// the resulting DNS packet does not exceed the UDP MTU.
-    pub fn set_txt_attribute(&self, key: String, value: Option<String>) -> anyhow::Result<()> {
+    pub fn set_txt_attribute(
+        &self,
+        key: String,
+        value: Option<String>,
+    ) -> Result<(), TxtAttributeError> {
         validate_txt_attribute(&key, value.as_deref())?;
         self.aref.send(guardian::Input::SetTxt(key, value));
         Ok(())
@@ -408,13 +453,11 @@ impl Drop for DropGuard {
     }
 }
 
-fn validate_txt_attribute(key: &str, value: Option<&str>) -> anyhow::Result<()> {
+fn validate_txt_attribute(key: &str, value: Option<&str>) -> Result<(), TxtAttributeError> {
     if key.is_empty() {
-        Err(anyhow!("Key may not be empty"))
+        Err(EmptyKeySnafu.build())
     } else if key.len() + value.as_ref().map(|v| v.len()).unwrap_or_default() > 254 {
-        Err(anyhow!(
-            "Key-value pair is too long, must be shorter than 254 bytes"
-        ))
+        Err(TooLongSnafu.build())
     } else {
         Ok(())
     }
@@ -480,10 +523,10 @@ mod tests {
             loop {
                 if let Some(peer) = rx.recv().await {
                     if peer.addrs().len() == 1 && peer.addrs()[0].1 == 9000 {
-                        return Ok(peer);
+                        return Ok::<_, snafu::Whatever>(peer);
                     }
                 } else {
-                    return Err(anyhow::anyhow!("Failed to receive updated peer"));
+                    snafu::whatever!("Failed to receive updated peer");
                 }
             }
         })

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,6 +1,6 @@
 use crate::IpClass;
-use anyhow::{bail, Context};
 use hickory_proto::op::Message;
+use snafu::prelude::*;
 use socket2::{Domain, Protocol, Socket, Type};
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4},
@@ -12,49 +12,101 @@ pub const MDNS_PORT: u16 = 5353;
 pub const MDNS_IPV4: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 251);
 pub const MDNS_IPV6: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0xfb);
 
-pub fn socket_v4() -> anyhow::Result<UdpSocket> {
-    let socket =
-        Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)).context("Socket::new")?;
-    socket
-        .set_reuse_address(true)
-        .context("set_reuse_address")?;
-    #[cfg(unix)]
-    socket.set_reuse_port(true).context("set_reuse_port")?;
-    socket
-        .bind(&SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, MDNS_PORT).into())
-        .context("bind")?;
-    socket
-        .set_multicast_loop_v4(true)
-        .context("set_multicast_loop_v4")?;
-    socket
-        .join_multicast_v4(&MDNS_IPV4, &Ipv4Addr::UNSPECIFIED)
-        .context("join_multicast_v4")?;
-    socket
-        .set_multicast_ttl_v4(16)
-        .context("set_multicast_ttl_v4")?;
-    socket.set_nonblocking(true).context("set_nonblocking")?;
-    UdpSocket::from_std(std::net::UdpSocket::from(socket)).context("from_std")
+#[derive(Debug)]
+#[doc(hidden)]
+pub enum IP {
+    Ipv4,
+    Ipv6,
 }
 
-pub fn socket_v6() -> anyhow::Result<UdpSocket> {
-    let socket =
-        Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP)).context("Socket::new")?;
+impl std::fmt::Display for IP {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IP::Ipv4 => write!(f, "IPv4"),
+            IP::Ipv6 => write!(f, "IPv6"),
+        }
+    }
+}
+
+/// Errors that can occur when creating and configuring an IPv4 or IPv6 socket.
+#[derive(Debug, Snafu)]
+pub enum SocketError {
+    #[snafu(display("{domain}: error creating new socket for"))]
+    NewSocket { domain: IP, source: std::io::Error },
+    #[snafu(display("{domain}: error setting the reuse address"))]
+    ReuseAddress { domain: IP, source: std::io::Error },
+    #[cfg(unix)]
+    #[snafu(display("{domain}: error setting the reuse port"))]
+    ReusePort { domain: IP, source: std::io::Error },
+    #[snafu(display("{domain}: error binding the socket for"))]
+    Bind { domain: IP, source: std::io::Error },
+    #[snafu(display("{domain}: error setting multicast loop"))]
+    SetMulticastLoop { domain: IP, source: std::io::Error },
+    #[snafu(display("{domain}: error joining multicast"))]
+    JoinMulticast { domain: IP, source: std::io::Error },
+    #[snafu(display("{domain}: error setting the multicast ttl"))]
+    MulticastTtl { domain: IP, source: std::io::Error },
+    #[snafu(display("{domain}: error setting the socket to non-blocking mode"))]
+    SetNonBlocking { domain: IP, source: std::io::Error },
+    #[snafu(display("{domain}: error creating a UDP socket from a standard socket"))]
+    UdpSocket { domain: IP, source: std::io::Error },
+    #[snafu(display("Cannot bind to IPv4 or IPv6"))]
+    CannotBind,
+}
+
+pub fn socket_v4() -> Result<UdpSocket, SocketError> {
+    let socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))
+        .context(NewSocketSnafu { domain: IP::Ipv4 })?;
     socket
         .set_reuse_address(true)
-        .context("set_reuse_address")?;
+        .context(ReuseAddressSnafu { domain: IP::Ipv4 })?;
     #[cfg(unix)]
-    socket.set_reuse_port(true).context("set_reuse_port")?;
+    socket
+        .set_reuse_port(true)
+        .context(ReusePortSnafu { domain: IP::Ipv4 })?;
+    socket
+        .bind(&SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, MDNS_PORT).into())
+        .context(BindSnafu { domain: IP::Ipv4 })?;
+    socket
+        .set_multicast_loop_v4(true)
+        .context(SetMulticastLoopSnafu { domain: IP::Ipv4 })?;
+    socket
+        .join_multicast_v4(&MDNS_IPV4, &Ipv4Addr::UNSPECIFIED)
+        .context(JoinMulticastSnafu { domain: IP::Ipv4 })?;
+    socket
+        .set_multicast_ttl_v4(16)
+        .context(MulticastTtlSnafu { domain: IP::Ipv4 })?;
+    socket
+        .set_nonblocking(true)
+        .context(SetNonBlockingSnafu { domain: IP::Ipv4 })?;
+    UdpSocket::from_std(std::net::UdpSocket::from(socket))
+        .context(UdpSocketSnafu { domain: IP::Ipv4 })
+}
+
+pub fn socket_v6() -> Result<UdpSocket, SocketError> {
+    let socket = Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP))
+        .context(NewSocketSnafu { domain: IP::Ipv6 })?;
+    socket
+        .set_reuse_address(true)
+        .context(ReuseAddressSnafu { domain: IP::Ipv6 })?;
+    #[cfg(unix)]
+    socket
+        .set_reuse_port(true)
+        .context(ReusePortSnafu { domain: IP::Ipv6 })?;
     socket
         .bind(&SocketAddr::from((Ipv6Addr::UNSPECIFIED, MDNS_PORT)).into())
-        .context("bind")?;
+        .context(BindSnafu { domain: IP::Ipv6 })?;
     socket
         .set_multicast_loop_v6(true)
-        .context("set_multicast_loop_v6")?;
+        .context(SetMulticastLoopSnafu { domain: IP::Ipv6 })?;
     socket
         .join_multicast_v6(&MDNS_IPV6, 0)
-        .context("join_multicast_v6")?;
-    socket.set_nonblocking(true).context("set_nonblocking")?;
-    UdpSocket::from_std(std::net::UdpSocket::from(socket)).context("from_std")
+        .context(JoinMulticastSnafu { domain: IP::Ipv6 })?;
+    socket
+        .set_nonblocking(true)
+        .context(SetNonBlockingSnafu { domain: IP::Ipv6 })?;
+    UdpSocket::from_std(std::net::UdpSocket::from(socket))
+        .context(UdpSocketSnafu { domain: IP::Ipv6 })
 }
 
 #[derive(Clone, Debug)]
@@ -64,7 +116,7 @@ pub struct Sockets {
 }
 
 impl Sockets {
-    pub fn new(class: IpClass) -> anyhow::Result<Self> {
+    pub fn new(class: IpClass) -> Result<Self, SocketError> {
         match class {
             IpClass::Auto => {
                 let socket = Self {
@@ -72,18 +124,18 @@ impl Sockets {
                     v6: socket_v6().ok().map(Arc::new),
                 };
                 if socket.v4.is_none() && socket.v6.is_none() {
-                    bail!("Socket cannot bind to ipv4 or ipv6");
+                    return Err(CannotBindSnafu.build());
                 }
                 Ok(socket)
             }
             _ => Ok(Self {
                 v4: class
                     .has_v4()
-                    .then(|| socket_v4().context("socket_v4").map(Arc::new))
+                    .then(|| socket_v4().map(Arc::new))
                     .transpose()?,
                 v6: class
                     .has_v6()
-                    .then(|| socket_v6().context("socket_v6").map(Arc::new))
+                    .then(|| socket_v6().map(Arc::new))
                     .transpose()?,
             }),
         }


### PR DESCRIPTION
In prep for releasing our 1.0, `iroh` is switching from using anyhow errors to concrete errors.

It would be really helpful for us if `swarm-discovery` could also use concrete errors as well, since errors in discovery do bubble up to our users.

I've switched out the `anyhow` errors for concrete errors using the `snafu` crate (that is the one I am most familiar with at the moment, since it is the crate we are using in `iroh`), and removed the `anyhow` dependency. Hopefully, this is acceptable. Please let me know if there is another way you would prefer this to go.