### PR TITLE
deps: update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,17 @@ documentation = "https://docs.rs/swarm-discovery"
 serde = ["dep:serde"]
 
 [dependencies]
-acto = { version = "0.7.4", features = ["tokio"] }
+acto = { version = "0.8.0", features = ["tokio"] }
 hickory-proto = "0.25.2"
 rand = "0.9.1"
 serde = { version = "1.0.219", features = ["derive"], optional = true }
-socket2 = { version = "0.5.10", features = ["all"] }
+socket2 = { version = "0.6", features = ["all"] }
 tokio = { version = "1.45.1", features = ["macros", "net", "rt", "time"] }
 thiserror = "2"
 tracing = "0.1.41"
 
 [dev-dependencies]
-if-addrs = "0.13.4"
+if-addrs = "0.14.0"
 ipc-channel = "0.20.0"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 


### PR DESCRIPTION
This updates `socket2` from `0.5` to `0.6` and `acto` from `0.7` to `0.8`. No code changes needed AFAICS.