### PR TITLE
Update to rand 0.10 and hickory-proto 0.26-beta and bump version to 0.6.0-alpha.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swarm-discovery"
-version = "0.5.0"
+version = "0.6.0-alpha.1"
 edition = "2021"
 authors = ["Roland Kuhn"]
 description = "Discovery service for IP-based swarms"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ serde = ["dep:serde"]
 
 [dependencies]
 acto = { version = "0.8.0", features = ["tokio"] }
-hickory-proto = "0.25.2"
-rand = "0.9.2"
+hickory-proto = { version = "0.26.0-beta.1", default-features = false }
+rand = "0.10"
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 socket2 = { version = "0.6", features = ["all"] }
 tokio = { version = "1.49.0", features = ["macros", "net", "rt", "time"] }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -5,13 +5,13 @@ use crate::{
 };
 use acto::{AcTokioRuntime, ActoCell, ActoInput, ActoRef};
 use hickory_proto::{
-    op::{Message, MessageType, Query},
+    op::{Message, MessageType, OpCode, Query},
     rr::{
         rdata::{self, TXT},
         DNSClass, Name, RData, Record, RecordType,
     },
 };
-use rand::{rng, Rng};
+use rand::{rng, RngExt};
 use std::{collections::BTreeMap, net::IpAddr, str::FromStr, time::Duration};
 
 const RESPONSE_DELAY: Duration = Duration::from_millis(100);
@@ -153,8 +153,7 @@ pub async fn sender(
 }
 
 fn make_query(service_name: &Name) -> Message {
-    let mut msg = Message::new();
-    msg.set_message_type(MessageType::Query);
+    let mut msg = Message::new(0, MessageType::Query, OpCode::Query);
     let mut query = Query::new();
     query.set_query_class(DNSClass::IN);
     query.set_query_type(RecordType::PTR);
@@ -165,8 +164,7 @@ fn make_query(service_name: &Name) -> Message {
 
 fn make_response(discoverer: &Discoverer, service_name: &Name) -> Option<Message> {
     if let Some(peer) = discoverer.peers.get(&discoverer.peer_id) {
-        let mut msg = Message::new();
-        msg.set_message_type(MessageType::Response);
+        let mut msg = Message::new(0, MessageType::Response, OpCode::Query);
         msg.set_authoritative(true);
 
         let my_srv_name = Name::from_str(&discoverer.peer_id)


### PR DESCRIPTION
This updates hickory-proto to 0.26-beta.1 to enable updating to rand 0.10 without duplicated dependencies.

Also bumps the version from 0.5.0 to 0.6.0-alpha.1.

It turns out that hickory is unfortunately in the public API of this crate in `SpawnError`:
```
$ cargo +nightly public-api | grep hickory
 Documenting swarm-discovery v0.5.0 (/home/philipp/program/work/swarm-discovery)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.54s
pub swarm_discovery::SpawnError::AppendServiceName::service_name: hickory_proto::rr::domain::name::Name
pub swarm_discovery::SpawnError::AppendServiceName::source: hickory_proto::error::ProtoError
pub swarm_discovery::SpawnError::NameFromPeerId::source: hickory_proto::error::ProtoError
pub swarm_discovery::SpawnError::ServiceName::source: hickory_proto::error::ProtoError
```

Which means we can't release this as a patch release. We might want to change this in the future to make releases in this crate less dependent on hickory, but that'd then be another PR.