### PR TITLE
deps: update hickory-proto to 0.26 and bump version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swarm-discovery"
-version = "0.6.0-alpha.2"
+version = "0.6.0"
 edition = "2021"
 authors = ["Roland Kuhn"]
 description = "Discovery service for IP-based swarms"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = ["dep:serde"]
 
 [dependencies]
 acto = { version = "0.8.0", features = ["tokio"] }
-hickory-proto = { version = "=0.26.0-beta.4", default-features = false }
+hickory-proto = { version = "0.26", default-features = false }
 rand = "0.10"
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 socket2 = { version = "0.6", features = ["all"] }


### PR DESCRIPTION
`hickory-proto@0.26.0` was released, this updates the crate from `0.26-beta.4` to `0.26`.
Also bumps the crate version from `0.6.0-alpha.2` to `0.6.0`.