### PR TITLE
fix: pin multicast egress and join the group per interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,9 +533,14 @@ mod tests {
             .spawn(&handle)
             .expect("Failed to spawn discoverer1");
 
-        // Second Discoverer (to verify the changes)
-        let discoverer2 =
-            Discoverer::new("test_service".to_string(), peer_id2).with_callback(move |id, peer| {
+        // Second Discoverer (to verify the changes). It uses the same
+        // multicast interface as the first one: multicast sent on the
+        // loopback interface is only delivered to members on the loopback
+        // interface, which also keeps this test independent of the host's
+        // default route.
+        let discoverer2 = Discoverer::new("test_service".to_string(), peer_id2)
+            .with_multicast_interfaces_v4(vec![Ipv4Addr::new(127, 0, 0, 1)])
+            .with_callback(move |id, peer| {
                 if id == peer_id1 {
                     tx.try_send(peer.clone()).ok();
                 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -136,11 +136,18 @@ pub fn socket_v4(interface_addr: Option<Ipv4Addr>) -> Result<UdpSocket, SocketEr
             source,
         })?;
 
-    // Join multicast group once on the default interface.
-    // Due to IP_MULTICAST_ALL (enabled by default on most systems),
-    // this socket will receive multicast packets from ALL interfaces,
-    // not just the default one. This simplifies multi-interface support
-    // for receiving, though sending still requires per-interface sockets.
+    // Join the multicast group once, on the interface of the default route.
+    //
+    // Group membership is per interface, so packets arriving on any other
+    // interface are not delivered to this socket. IP_MULTICAST_ALL would
+    // paper over this on Linux when another membership exists, but that
+    // socket option is Linux-only; on macOS and other BSD-derived systems
+    // reception from non-default interfaces does not work. The per-interface
+    // sockets cannot take over reception either: they are bound to a unicast
+    // address and therefore never match multicast-destined packets. Reception
+    // on further interfaces is instead set up by
+    // `Sockets::join_group_on_main_v4`, which joins the group per interface on
+    // this main wildcard socket.
     socket
         .join_multicast_v4(&MDNS_IPV4, &interface_addr.unwrap_or(Ipv4Addr::UNSPECIFIED))
         .map_err(|source| SocketError::JoinMulticast {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -75,6 +75,12 @@ pub enum SocketError {
         #[source]
         source: std::io::Error,
     },
+    #[error("{domain}: error setting the multicast interface")]
+    SetMulticastIf {
+        domain: IP,
+        #[source]
+        source: std::io::Error,
+    },
     #[error("{domain}: error setting the socket to non-blocking mode")]
     SetNonBlocking {
         domain: IP,
@@ -141,6 +147,20 @@ pub fn socket_v4(interface_addr: Option<Ipv4Addr>) -> Result<UdpSocket, SocketEr
             domain: IP::Ipv4,
             source,
         })?;
+
+    // Pin multicast egress to the requested interface. Binding to the
+    // interface address alone does not reliably select the outgoing
+    // interface for multicast: the kernel falls back to the routing table,
+    // which can pick a different interface or fail with "no route to host"
+    // (for example for interfaces without a multicast route entry).
+    if let Some(addr) = interface_addr {
+        socket
+            .set_multicast_if_v4(&addr)
+            .map_err(|source| SocketError::SetMulticastIf {
+                domain: IP::Ipv4,
+                source,
+            })?;
+    }
 
     socket
         .set_multicast_ttl_v4(16)
@@ -241,7 +261,7 @@ impl Sockets {
         }
         let interface_sockets_v4 = Arc::new(RwLock::new(interface_sockets_v4));
 
-        match class {
+        let sockets = match class {
             IpClass::Auto => {
                 let socket = Self {
                     v4: socket_v4(None).ok().map(Arc::new),
@@ -251,9 +271,9 @@ impl Sockets {
                 if socket.v4.is_none() && socket.v6.is_none() {
                     return Err(SocketError::CannotBind);
                 }
-                Ok(socket)
+                socket
             }
-            _ => Ok(Self {
+            _ => Self {
                 v4: class
                     .has_v4()
                     .then(|| socket_v4(None).map(Arc::new))
@@ -263,8 +283,12 @@ impl Sockets {
                     .then(|| socket_v6().map(Arc::new))
                     .transpose()?,
                 interface_sockets_v4: interface_sockets_v4.clone(),
-            }),
+            },
+        };
+        for addr in sockets.get_all_interface_addresses_v4() {
+            sockets.join_group_on_main_v4(addr);
         }
+        Ok(sockets)
     }
 
     pub fn v4(&self) -> Option<Arc<UdpSocket>> {
@@ -273,6 +297,39 @@ impl Sockets {
 
     pub fn v6(&self) -> Option<Arc<UdpSocket>> {
         self.v6.as_ref().map(Arc::clone)
+    }
+
+    /// Joins the multicast group on the given interface on the main wildcard
+    /// IPv4 socket.
+    ///
+    /// Group membership is per interface: the wildcard socket initially only
+    /// joins the group on the interface of the default route, so multicast
+    /// arriving on other interfaces is not delivered to it (except on
+    /// platforms with `IP_MULTICAST_ALL` semantics and an existing
+    /// system-wide membership). The per-interface sockets cannot take over
+    /// reception either, because they are bound to a unicast address and
+    /// therefore never match multicast-destined packets. Joining the group
+    /// per interface on the wildcard socket makes reception work on all
+    /// interfaces.
+    fn join_group_on_main_v4(&self, addr: Ipv4Addr) {
+        if let Some(v4) = &self.v4 {
+            match v4.join_multicast_v4(MDNS_IPV4, addr) {
+                Ok(()) => tracing::debug!("joined multicast group on interface {}", addr),
+                // Already being a member on this interface (e.g. the default
+                // interface joined at socket creation) is not a problem.
+                Err(e) => tracing::debug!("could not join multicast group on {}: {}", addr, e),
+            }
+        }
+    }
+
+    /// Leaves the multicast group on the given interface on the main wildcard
+    /// IPv4 socket. See [`Self::join_group_on_main_v4`].
+    fn leave_group_on_main_v4(&self, addr: Ipv4Addr) {
+        if let Some(v4) = &self.v4 {
+            if let Err(e) = v4.leave_multicast_v4(MDNS_IPV4, addr) {
+                tracing::debug!("could not leave multicast group on {}: {}", addr, e);
+            }
+        }
     }
 
     /// Add a new IPv4 interface for multicast operations.
@@ -291,12 +348,15 @@ impl Sockets {
         // Create the interface-specific socket for sending
         let socket = socket_v4(Some(addr))?;
 
-        let mut interfaces = self.interface_sockets_v4.write().unwrap();
-        // need to recheck since we dropped the lock in between
-        interfaces.entry(addr).or_insert_with(|| {
-            tracing::info!("Added interface {} for multicast", addr);
-            Arc::new(socket)
-        });
+        {
+            let mut interfaces = self.interface_sockets_v4.write().unwrap();
+            // need to recheck since we dropped the lock in between
+            interfaces.entry(addr).or_insert_with(|| {
+                tracing::info!("Added interface {} for multicast", addr);
+                Arc::new(socket)
+            });
+        }
+        self.join_group_on_main_v4(addr);
         Ok(())
     }
 
@@ -310,6 +370,7 @@ impl Sockets {
             drop(interfaces);
             // drop socket outside the lock
             drop(socket);
+            self.leave_group_on_main_v4(addr);
             tracing::info!("Removed interface {} from multicast", addr);
 
             true


### PR DESCRIPTION
## Description

Multicast behavior is per network interface, both for sending and for receiving. The per-interface socket support has two gaps that surface on multi-homed hosts:

1. **Sending**: interface-specific sockets are bound to the interface address, but `IP_MULTICAST_IF` is never set. Binding alone does not reliably select the outgoing interface for multicast. The kernel falls back to the routing table, which can pick a different interface than the one the socket was created for, or fail outright with "no route to host" (`ENETUNREACH` on Linux, `EHOSTUNREACH` on macOS) when the routing table has no usable multicast route for that source. This is easy to reproduce with virtual interfaces (TUN/TAP style devices) and on hosts whose default route does not match the target interface.

2. **Receiving**: the wildcard socket joins the multicast group once, on the interface of the default route. Group membership is per interface, so packets arriving on any other interface are not delivered to it. The code comment relies on `IP_MULTICAST_ALL`, but that socket option is Linux-only; on macOS and other BSD-derived systems reception from non-default interfaces does not work. The per-interface sockets cannot take over reception either: they are bound to a unicast address and therefore never match multicast-destined packets.

Combined effect: two peers on a shared network fail to discover each other whenever either host's default route points at a different interface (a second uplink, a VPN, a tethered connection), even though unicast connectivity between them is fine.

Changes:

- `socket_v4`: when an interface address is given, set `IP_MULTICAST_IF` so multicast egress is pinned to that interface explicitly. Adds a `SetMulticastIf` variant to the private `SocketError`.
- `Sockets::new` / `Sockets::add_interface_v4`: additionally join the multicast group on that interface on the main wildcard socket, so reception works on all interfaces on all platforms, independent of `IP_MULTICAST_ALL`. `remove_interface_v4` leaves the group again.
- `test_change_addresses`: the second discoverer now also pins its multicast interface to loopback. Previously the test passed only because the unpinned loopback send leaked onto the default-route interface, where the second discoverer's wildcard membership happened to receive it. With pinned egress that accidental path is gone; the explicit configuration also makes the test independent of the host's default route.

Verified on macOS (15.x, multi-homed: two Ethernet interfaces plus a virtual interface) and Linux (aarch64):

- Before: sends from interface-specific sockets either left through the default-route interface (wrong source interface) or failed with "no route to host" on the virtual interface. A receiver pinned to a non-default interface never saw group traffic.
- After: every configured interface carries announcements with the matching source address, and packets arriving on non-default interfaces are delivered. Confirmed with per-interface multicast listeners and packet injection on each interface.

`cargo test`, `cargo clippy` and `cargo fmt` are clean (one pre-existing clippy warning about a large `Err` variant is untouched).

## Breaking Changes

None. `SocketError` lives in a private module, so the new variant is not visible in the public API. Behavior on single-interface hosts is unchanged.

## Notes & open questions

- This fix is driven in practice by n0-computer/iroh-address-lookups#7, which makes `iroh-mdns-address-lookup` configure per-interface multicast automatically on multi-homed hosts.

- The per-interface receiver tasks spawned by the guardian never receive anything, because those sockets are bound to a unicast address and multicast-destined packets do not match them. Reception now happens through the wildcard socket's per-interface memberships. I left the receiver tasks untouched to keep the diff small, but they could be removed as a follow-up if you agree they are dead code.
- IPv6 multicast still uses only the default interface; this change is IPv4 only, matching the existing multi-interface support.

## Change checklist

- [x] Self-review.
- [x] Documentation updates, if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented. (None.)
